### PR TITLE
Bugfix - Updated Database conecction to use SSL

### DIFF
--- a/src/sequelize.ts
+++ b/src/sequelize.ts
@@ -15,6 +15,9 @@ export default function (app: Application): void {
     define: {
       freezeTableName: true,
     },
+    dialectOptions: {
+      ssl: true,
+    },
     models: [`${__dirname}/models`],
   });
 


### PR DESCRIPTION
Herku started requiring ssl connection to external sources 

https://stackoverflow.com/questions/25000183/node-js-postgresql-error-no-pg-hba-conf-entry-for-host
https://help.heroku.com/DR0TTWWD/seeing-fatal-no-pg_hba-conf-entry-errors-in-postgres

> The authentication failed because the connection didn't use SSL encryption: (SSL off). All Heroku Postgres production databases require using SSL connections to ensure that communications between applications and the database remain secure. If your client is not using SSL to connect to your database, you would see these errors even if you're using the right credentials to connect to it.